### PR TITLE
Install multilib on amd64 only

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,9 +34,9 @@ RUN apt-get update \
     file \
     flex \
     g++ \
-    g++-multilib \
+    $(dpkg --print-architecture | grep -q "amd64" && echo "g++-multilib" || echo "") \
     gawk \
-    gcc-multilib \
+    $(dpkg --print-architecture | grep -q "amd64" && echo "gcc-multilib" || echo "") \
     gettext \
     git \
     gnupg \


### PR DESCRIPTION
It seems that multilib `gcc`/`g++` is only available for amd64:
- https://launchpad.net/ubuntu/noble/amd64/gcc-multilib vs. https://launchpad.net/ubuntu/noble/arm64/gcc-multilib 
- https://launchpad.net/ubuntu/noble/amd64/g++-multilib vs. https://launchpad.net/ubuntu/noble/arm64/g++-multilib

This PR should enable builds on both `amd64` (multilib as per [OpenWRT docs](https://openwrt.org/docs/guide-developer/toolchain/install-buildsystem#debianubuntumint)) as well as `arm64`.